### PR TITLE
chore: remove unused `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-polars[xlsx2csv]
-xlsxwriter
-
-# For typing
-numpy


### PR DESCRIPTION
The requirements are now included in the `pyproject.toml` file.